### PR TITLE
Change Contact to Community

### DIFF
--- a/template/Views/Home/Index.cshtml
+++ b/template/Views/Home/Index.cshtml
@@ -41,6 +41,6 @@
     	<h5>Get involved with the OpenShift community</h5>
     	The OpenShift community is filled with a wealth of knowledge that can make working
     	with OpenShift a very enjoyable experience.
-    	@Html.ActionLink("Learn More...", "Contact", "Home")
+    	@Html.ActionLink("Learn More...", "Community", "Home")
     </li>
 </ol>


### PR DESCRIPTION
...because this was a given route to the community page of this great new landing page. The old route to Contact result in an 404 error.
